### PR TITLE
Voiio: updated proof link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ Something is missing?  Create a pull request!
         ,
         [jobs](https://vimcar.de/career)
     * [voiio GmbH](https://www.voiio.de/) —
-         [proof](https://voiio.de/job/software-engineer-python-django-berlin/)
+         [proof](https://stackshare.io/companies/voiio)
          ,
          [github](https://github.com/voiio)
          ,

--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ Something is missing?  Create a pull request!
         ,
         [jobs](https://vimcar.de/career)
     * [voiio GmbH](https://www.voiio.de/) —
-         [proof](https://stackshare.io/companies/voiio)
+         [proof](https://stackshare.io/voiio/voiio-platform)
          ,
          [github](https://github.com/voiio)
          ,

--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ Something is missing?  Create a pull request!
         ,
         [jobs](https://vimcar.de/career)
     * [voiio GmbH](https://www.voiio.de/) —
-         [proof](https://stackshare.io/voiio/voiio-platform)
+         [proof](https://voiio.de/datenschutz/sicherheit/)
          ,
          [github](https://github.com/voiio)
          ,


### PR DESCRIPTION
The job position link is not available any more, however, stackshare link can be used as a proof that Voiio is using Django <3.